### PR TITLE
Add "now calling" view

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -148,6 +148,28 @@ body.welcome {
   font-size: 1.7em;
 }
 
+/****************************
+ * in attendees/new
+ */
+.welcome .calling-member {
+  padding-top: 7%;
+}
+
+.welcome .calling-member .loading {
+  padding-top: 0.7em;
+  padding-bottom: 0.7em;
+}
+
+.welcome .calling-member .list-group-item {
+  padding-top: 20px;
+  padding-bottom: 20px;
+}
+
+.welcome .calling-member .messages {
+  height: 15em;
+}
+
+
 /**********************************************************
  * in Admin
  */

--- a/app/assets/stylesheets/attendees.css.scss
+++ b/app/assets/stylesheets/attendees.css.scss
@@ -1,0 +1,52 @@
+.loading-balloon {
+  $ti-color-bg: #8BC34A;
+  background-color: $ti-color-bg;
+  width: auto;
+  border-radius: 50px;
+  padding: 20px;
+  display: table;
+  margin: 0 auto;
+  position: relative;
+  animation: 2s bulge infinite ease-out;
+  &:before, &:after {
+    content: '';
+    position: absolute;
+    bottom: -2px;
+    left: -2px;
+    height: 20px;
+    width: 20px;
+    border-radius: 50%;
+    background-color: $ti-color-bg;
+  }
+  &:after {
+    height: 10px;
+    width: 10px;
+    left: -10px;
+    bottom: -10px;
+  }
+  span {
+    height: 15px;
+    width: 15px;
+    float: left;
+    margin: 0 1px;
+    background-color: #e7eae3;
+    display: block;
+    border-radius: 50%;
+    opacity: 0.4;
+    @for $i from 1 through 3 {
+      &:nth-of-type(#{$i}){
+        animation: 1s blink infinite ($i * .3333s);
+      }
+    }
+  }
+}
+@keyframes blink{
+  50% {
+    opacity: 1;
+  }
+}
+@keyframes bulge{
+  50% {
+    transform: scale(1.05);
+  }
+}

--- a/app/controllers/attendees_controller.rb
+++ b/app/controllers/attendees_controller.rb
@@ -32,7 +32,7 @@ class AttendeesController < ApplicationController
     res = notifier.ping message
 
     if res.code_type == Net::HTTPOK
-      redirect_to root_path, notice: 'ただいまお呼び出ししています。'
+      render :new
     else
       redirect_to members_path, alert: 'お呼び出しに失敗しました。'
     end

--- a/app/views/attendees/new.html.erb
+++ b/app/views/attendees/new.html.erb
@@ -1,0 +1,79 @@
+<section class="calling-member">
+  <div class="container">
+    <div class="row loading">
+      <div class="col-md-12">
+        <div class="loading-balloon">
+          <span></span>
+          <span></span>
+          <span></span>
+        </div>
+      </div>
+    </div>
+    <div class="row messages">
+      <div class="col-md-12">
+        <h3>お呼び出ししています</h3>
+        <p>しばらくお待ち下さい。</p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-12">
+        <%= link_to '呼び出しをキャンセルする', '#', class: 'list-group-item btn-material-red', 'data-toggle' => 'modal', 'data-target' => '#attendCancel' %>
+        <div class="modal fade attendMember" id="attendCancel" tabindex="-1" role="dialog" aria-labelledby="dialogHeader" area-hidden="true">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">&nbsp;</h4>
+              </div>
+              <div class="modal-body">
+                <div class="container-fluid">
+                  <div class="row">
+                    <div class="col-md-12">
+                      <p class="text-left">呼び出しをキャンセルし、トップページへ戻ります。</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="modal-footer">
+                <%= form_tag(root_path, method: :get, id: 'attendCancelForm') do%>
+                  <button type="button" class="btn btn-default btn-lg" data-dismiss="modal">呼び出しをつづける</button>
+                  <%= button_tag '呼び出しをキャンセルする', class: 'btn btn-warning btn-lg', data: { disable_with: 'Sending...' }, form: 'attendCancelForm' %>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-12">
+        <%= link_to '（社員向け）応対しました', '#', class: 'list-group-item btn-material-grey', 'data-toggle' => 'modal', 'data-target' => '#attendFinish' %>
+        <div class="modal fade attendMember" id="attendFinish" tabindex="-1" role="dialog" aria-labelledby="dialogHeader" area-hidden="true">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">&nbsp;</h4>
+              </div>
+              <div class="modal-body">
+                <div class="container-fluid">
+                  <div class="row">
+                    <div class="col-md-12">
+                      <p class="text-left">こちらは<strong>応対した<%= Settings.company.name_kana %>社員が操作</strong>します。<br>応対が完了しましたか？</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="modal-footer">
+                <%= form_tag(root_path, method: :get, id: 'attendFinishForm') do%>
+                <button type="button" class="btn btn-default btn-lg" data-dismiss="modal">キャンセル</button>
+                  <%= button_tag '応対しました', class: 'btn btn-primary btn-lg', data: { disable_with: 'Sending...' }, form: 'attendFinishForm' %>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/spec/controllers/attendees_controller_spec.rb
+++ b/spec/controllers/attendees_controller_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe AttendeesController, type: :controller do
         ).to_return(status: 200)
 
         get :create, { member_id: member.id }
-        expect(response).to redirect_to root_path
+        expect(response).to have_http_status :success
+        expect(response).to render_template :new
       end
     end
 
@@ -41,7 +42,8 @@ RSpec.describe AttendeesController, type: :controller do
         ).to_return(status: 200)
 
         get :create, { member_id: member.id }
-        expect(response).to redirect_to root_path
+        expect(response).to have_http_status :success
+        expect(response).to render_template :new
       end
     end
 
@@ -54,7 +56,8 @@ RSpec.describe AttendeesController, type: :controller do
         ).to_return(status: 200)
 
         get :create
-        expect(response).to redirect_to root_path
+        expect(response).to have_http_status :success
+        expect(response).to render_template :new
       end
     end
 


### PR DESCRIPTION
「呼び出し中」を alert じゃなくて専用画面にした。

さらに「呼び出しのキャンセル」と「応対完了」の準備。
いまは root_path に飛ばすだけになってるが、それぞれ状況を Slack に再通知させる予定。

また、ゆくゆくは「呼び出し履歴」を保存するようにしたいので、そこで対応結果を保存するだろうという想像。
