### PR TITLE
管理者が社員を追加できるようにする

### DIFF
--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -9,6 +9,12 @@ class Admin::MembersController < Admin::ApplicationController
     @members = Member.all.reorder(:id)
   end
 
+  # GET /admin/members/new
+  def new
+    @title = '社員新規登録'
+    @member = Member.new
+  end
+
   # GET /admin/members/:id/edit
   def edit
     @title = '社員情報編集'

--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -15,6 +15,16 @@ class Admin::MembersController < Admin::ApplicationController
     @member = Member.new
   end
 
+  # POST /admin/members
+  def create
+    @member = Member.new(member_params)
+    if @member.save
+      redirect_to edit_admin_member_path(id: @member.id), notice: '作成しました'
+    else
+      render :new
+    end
+  end
+
   # GET /admin/members/:id/edit
   def edit
     @title = '社員情報編集'

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -19,12 +19,32 @@ class Member < ActiveRecord::Base
     family_name = auth_hash[:info][:last_name]
     image_url   = auth_hash[:info][:image]
 
-    Member.find_or_create_by(provider: provider, uid: uid) do |member|
-      member.email       = email
-      member.given_name  = given_name
-      member.family_name = family_name
-      member.image_url   = image_url
+    member = Member.find_by(email: email)
+
+    unless member
+      # 存在しなければ新規登録
+      return Member.create do |member|
+        member.provider    = provider
+        member.uid         = uid
+        member.email       = email
+        member.given_name  = given_name
+        member.family_name = family_name
+        member.image_url   = image_url
+      end
     end
+
+    unless member.uid
+      # 存在してるけど uid を持っていないのは
+      # 管理者に作られた Member なので更新しておく
+      member.provider    = provider
+      member.uid         = uid
+      member.given_name  = given_name  unless member.given_name.presence
+      member.family_name = family_name unless member.family_name.presence
+      member.image_url   = image_url   unless member.image_url.presence
+      member.save
+    end
+
+    member
   end
 
   # Members search

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,8 +1,8 @@
 class Member < ActiveRecord::Base
   belongs_to :group
 
-  validates_presence_of :provider, :uid, :email
-  validates_uniqueness_of :uid, scope: :provider
+  validates_presence_of :email
+  validates_uniqueness_of :uid, scope: :provider, allow_blank: true
   validates_uniqueness_of :email
 
   default_scope { order(:family_name_kana, :family_name, :email) }

--- a/app/views/admin/members/index.html.erb
+++ b/app/views/admin/members/index.html.erb
@@ -1,6 +1,6 @@
 <div class="container-fluid">
   <div class="row">
-    <p class="text-right"><%= link_to '新規登録', '#', class: 'btn btn-info' %></p>
+    <p class="text-right"><%= link_to '新規登録', new_admin_member_path, class: 'btn btn-info' %></p>
   </div>
   <table class="table table-hover">
     <thead>

--- a/app/views/admin/members/index.html.erb
+++ b/app/views/admin/members/index.html.erb
@@ -25,7 +25,7 @@
             <% kana = "#{member.family_name_kana} #{member.given_name_kana}".strip.presence %>
             <%= "#{member.family_name} #{member.given_name}" %><%= "（#{kana}）" if kana %>
           </td>
-          <td><% if member.slack_identifier %>@<%= member.slack_identifier %><% end %></td>
+          <td><% if member.slack_identifier.presence %>@<%= member.slack_identifier %><% end %></td>
           <td><%= member.email %></td>
           <td><% if member.image_url %><i class="glyphicon glyphicon-ok"></i><% end %></td>
           <td><% if member.uid %><i class="glyphicon glyphicon-ok"></i><% end %></td>

--- a/app/views/admin/members/new.html.erb
+++ b/app/views/admin/members/new.html.erb
@@ -1,0 +1,3 @@
+<div class="container-fluid">
+  <%= render 'form' %>
+</div>

--- a/db/migrate/20151217110120_change_columns_to_member.rb
+++ b/db/migrate/20151217110120_change_columns_to_member.rb
@@ -1,0 +1,6 @@
+class ChangeColumnsToMember < ActiveRecord::Migration
+  def change
+    change_column :members, :provider, :string, null: true
+    change_column :members, :uid, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151205091939) do
+ActiveRecord::Schema.define(version: 20151217110120) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,8 +27,8 @@ ActiveRecord::Schema.define(version: 20151205091939) do
   add_index "groups", ["order"], name: "idx_groups_order", using: :btree
 
   create_table "members", force: :cascade do |t|
-    t.string   "provider",             null: false
-    t.string   "uid",                  null: false
+    t.string   "provider"
+    t.string   "uid"
     t.string   "email",                null: false
     t.string   "given_name"
     t.string   "given_name_kana"

--- a/spec/controllers/admin/members_controller_spec.rb
+++ b/spec/controllers/admin/members_controller_spec.rb
@@ -42,6 +42,21 @@ RSpec.describe Admin::MembersController, type: :controller do
     end
   end
 
+  describe 'GET #new' do
+    subject { get :new }
+    it_behaves_like 'Rejecting unknown member'
+
+    context 'has logged-in' do
+      include_context 'member logged-in'
+
+      it 'returns http success' do
+        subject
+        expect(response).to have_http_status(:success)
+        expect(assigns(:title)).to eq '社員新規登録'
+      end
+    end
+  end
+
   describe 'GET #edit' do
     subject { get :edit, { id: 1 } }
     it_behaves_like 'Rejecting unknown member'

--- a/spec/controllers/admin/members_controller_spec.rb
+++ b/spec/controllers/admin/members_controller_spec.rb
@@ -57,6 +57,35 @@ RSpec.describe Admin::MembersController, type: :controller do
     end
   end
 
+  describe 'POST #create' do
+    subject { post :create, { member: {} } }
+    it_behaves_like 'Rejecting unknown member'
+
+    context 'has logged-in' do
+      include_context 'member logged-in'
+
+      let(:request_params) do
+        {
+          member: {
+            email: 'spec@example.com',
+            given_name: '太郎', family_name: '山田',
+            given_name_kana: 'たろう', family_name_kana: 'やまだ',
+            given_name_alphabet: 'Taro', family_name_alphabet: 'Yamada',
+            slack_identifier: 'ytaro'
+          }
+        }
+      end
+
+      it 'returns http success' do
+        expect do
+          post :create, request_params
+        end.to change { Member.count }.by(1)
+        # NOTE: default_scope よくないな… > reorder(nil)
+        expect(response).to redirect_to "/admin/members/#{Member.reorder(nil).last.id}/edit"
+      end
+    end
+  end
+
   describe 'GET #edit' do
     subject { get :edit, { id: 1 } }
     it_behaves_like 'Rejecting unknown member'

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -2,12 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Member, type: :model do
   describe 'validation' do
-    describe '#provider' do
-      it { should validate_presence_of(:provider) }
-    end
-
     describe '#uid' do
-      it { should validate_presence_of(:uid) }
       it 'should require unique value for uid scoped to provider' do
         create(:member, provider: 'google', uid: '10000567890')
         expect(build(:member, provider: 'google',  uid: '10000567890')).to be_invalid

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Member, type: :model do
     end
 
     context 'has no member' do
-      it 'return create member' do
+      it 'returns create member' do
         member = nil
         expect {
           member = Member.find_or_create_from_auth_hash(auth_hash)
@@ -41,10 +41,37 @@ RSpec.describe Member, type: :model do
       end
     end
 
-    context 'has member already' do
-      before { @member = create(:member, provider: 'google', uid: '1000067890') }
+    context 'has member already associated google' do
+      before do
+        @member = create(
+          :member,
+          provider: 'google', uid: '1000067890',
+          email: 'hanako@example.com'
+        )
+      end
 
-      it 'return find member' do
+      it 'returns find member' do
+        member = nil
+        expect {
+          member = Member.find_or_create_from_auth_hash(auth_hash)
+        }.to_not change{ Member.count }
+        expect(member).to be_persisted
+        expect(member.id).to eq @member.id
+        expect(member.provider).to eq 'google'
+        expect(member.uid).to eq '1000067890'
+      end
+    end
+
+    context 'has member already created by admin' do
+      before do
+        @member = create(
+          :member,
+          provider: nil, uid: nil,
+          email: 'hanako@example.com'
+        )
+      end
+
+      it 'returns update member' do
         member = nil
         expect {
           member = Member.find_or_create_from_auth_hash(auth_hash)


### PR DESCRIPTION
- [x] OmniAuthのために作成した :provider, :uid カラムを必須じゃなくす
- [x] 管理画面からMemberを登録できるようにする
    - この方法で作成したユーザは :provider, :uid を埋めない
- [x] 管理者が追加したユーザが Google ログインした場合は :email でマージする